### PR TITLE
Compiler Warning Fixed

### DIFF
--- a/src/node.cpp
+++ b/src/node.cpp
@@ -209,7 +209,7 @@ int main(int argc, char * argv[]) {
     nh_private.param<bool>("angle_compensate", angle_compensate, false);
     nh_private.param<std::string>("scan_mode", scan_mode, std::string());
 
-    ROS_INFO("RPLIDAR running on ROS package rplidar_ros. SDK Version:"RPLIDAR_SDK_VERSION"");
+    ROS_INFO("RPLIDAR running on ROS package rplidar_ros. SDK Version:" RPLIDAR_SDK_VERSION "");
 
     u_result     op_result;
 


### PR DESCRIPTION
The When you compile the source code you get a warning,  compiler detected that a space is needed between a literal and string macro because a compiler error might occur in later C++ standards. 

[Warning]
invalid suffix on literal; C++11 requires a space between literal and string macro [-Wliteral-suffix]